### PR TITLE
Use qualified column names in pivot query

### DIFF
--- a/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
+++ b/src/Illuminate/Database/Eloquent/Relations/Concerns/InteractsWithPivotTable.php
@@ -429,7 +429,7 @@ trait InteractsWithPivotTable
                     return 0;
                 }
 
-                $query->whereIn($this->relatedPivotKey, (array) $ids);
+                $query->whereIn($this->getQualifiedRelatedPivotKeyName(), (array) $ids);
             }
 
             // Once we have all of the conditions set on the statement, we are ready
@@ -544,7 +544,7 @@ trait InteractsWithPivotTable
             $query->whereIn(...$arguments);
         }
 
-        return $query->where($this->foreignPivotKey, $this->parent->{$this->parentKey});
+        return $query->where($this->getQualifiedForeignPivotKeyName(), $this->parent->{$this->parentKey});
     }
 
     /**

--- a/tests/Database/DatabaseEloquentMorphToManyTest.php
+++ b/tests/Database/DatabaseEloquentMorphToManyTest.php
@@ -47,9 +47,9 @@ class DatabaseEloquentMorphToManyTest extends TestCase
         $relation = $this->getMockBuilder(MorphToMany::class)->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $query = m::mock(stdClass::class);
         $query->shouldReceive('from')->once()->with('taggables')->andReturn($query);
-        $query->shouldReceive('where')->once()->with('taggable_id', 1)->andReturn($query);
+        $query->shouldReceive('where')->once()->with('taggables.taggable_id', 1)->andReturn($query);
         $query->shouldReceive('where')->once()->with('taggable_type', get_class($relation->getParent()))->andReturn($query);
-        $query->shouldReceive('whereIn')->once()->with('tag_id', [1, 2, 3]);
+        $query->shouldReceive('whereIn')->once()->with('taggables.tag_id', [1, 2, 3]);
         $query->shouldReceive('delete')->once()->andReturn(true);
         $relation->getQuery()->shouldReceive('getQuery')->andReturn($mockQueryBuilder = m::mock(stdClass::class));
         $mockQueryBuilder->shouldReceive('newQuery')->once()->andReturn($query);
@@ -63,7 +63,7 @@ class DatabaseEloquentMorphToManyTest extends TestCase
         $relation = $this->getMockBuilder(MorphToMany::class)->setMethods(['touchIfTouching'])->setConstructorArgs($this->getRelationArguments())->getMock();
         $query = m::mock(stdClass::class);
         $query->shouldReceive('from')->once()->with('taggables')->andReturn($query);
-        $query->shouldReceive('where')->once()->with('taggable_id', 1)->andReturn($query);
+        $query->shouldReceive('where')->once()->with('taggables.taggable_id', 1)->andReturn($query);
         $query->shouldReceive('where')->once()->with('taggable_type', get_class($relation->getParent()))->andReturn($query);
         $query->shouldReceive('whereIn')->never();
         $query->shouldReceive('delete')->once()->andReturn(true);


### PR DESCRIPTION
Use qualified column names in pivot query. This allows a user to extend the query with a join that may include ambiguous column names.

Old extended query example:
```sql
# SQLSTATE[23000]: Integrity constraint violation: 1052
# Column 'rule_id' in WHERE clause is ambiguous

SELECT `cmp_rule`.*
FROM   `cmp_rule`
       RIGHT JOIN `reg_rule`
               ON `reg_rule`.`rule_id` = `cmp_rule`.`rule_id`
WHERE  `base_id` = 1
       AND `rule_id` IN ( 5 ) 
```

New extended query example:
```sql
SELECT `cmp_rule`.*
FROM   `cmp_rule`
       RIGHT JOIN `reg_rule`
               ON `reg_rule`.`rule_id` = `cmp_rule`.`rule_id`
WHERE  `cmp_rule`.`base_id` = 1
       AND `cmp_rule`.`rule_id` IN ( 5 ) 
```

I also created a issue for this PR here: https://github.com/laravel/framework/issues/36718
